### PR TITLE
ci(github): set WasmApplicationEnvironmentName on Blazor publish

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -165,7 +165,12 @@ jobs:
 
       - name: Build and Publish Blazor WebAssembly
         if: env.NEEDS_DOTNET == 'true' && inputs.webPath != ''
-        run: dotnet publish ${{ inputs.webPath }} --configuration ${{ inputs.buildConfiguration }} --no-restore --output ${{ env.outputPath }}
+        run: |
+          WASM_ENV="Development"
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            WASM_ENV="Production"
+          fi
+          dotnet publish ${{ inputs.webPath }} --configuration ${{ inputs.buildConfiguration }} --no-restore --output ${{ env.outputPath }} -p:WasmApplicationEnvironmentName=$WASM_ENV
 
       - name: Install jq
         if: inputs.functions != '[]' || inputs.spaSites != '[]'


### PR DESCRIPTION
## Summary

Passes `-p:WasmApplicationEnvironmentName` to `dotnet publish` when building Blazor WebAssembly projects so the correct environment-specific `appsettings.{Env}.json` is loaded at runtime. Branch builds use `Development`; tag builds use `Production`.

Previously the property was omitted entirely, causing the .NET SDK to default to `Production` for all Release builds regardless of environment.

## Changes

- **`build-deploy.yaml`** — `Build and Publish Blazor WebAssembly` step now detects `refs/tags/*` to set `WASM_ENV=Production`, otherwise `Development`, and passes `-p:WasmApplicationEnvironmentName=$WASM_ENV` to `dotnet publish`

## Validation

- Verified locally that `applicationEnvironment` in the published `_framework/dotnet.*.js` bundle reflects the correct environment when `WasmApplicationEnvironmentName` is set
- Confirmed `WasmApplicationEnvironmentName` is the correct MSBuild property name for .NET 9 Blazor WASM (not `WasmApplicationEnvironment`)

## Notes for Reviewers

Consumers of this template that use `webPath` will now get environment-aware config loading automatically. No changes required in consuming repos beyond having the appropriate `appsettings.{Env}.json` files present in `wwwroot`.