### PR TITLE
ci(github): add JSON-based NuGet versioning with publish-preview and publish-release workflows

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,0 +1,120 @@
+name: Publish Preview
+
+on:
+  workflow_call:
+    inputs:
+      solution:
+        description: "Solution file name"
+        required: true
+        type: string
+      packageId:
+        description: "NuGet package ID (must match a key in eng/package-versioning.json)"
+        required: true
+        type: string
+      versionProfile:
+        description: "Profile name for by-profile packages (e.g. net9)"
+        required: false
+        default: ""
+        type: string
+      hasTests:
+        description: "Run tests before publish"
+        required: false
+        default: true
+        type: boolean
+      dotnetVersion:
+        description: ".NET SDK version. Falls back to dotnetSdk from JSON profile if not provided."
+        required: false
+        default: ""
+        type: string
+    secrets:
+      NUGET_API_KEY:
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Validate manifest exists
+        run: |
+          if [ ! -f "eng/package-versioning.json" ]; then
+            echo "❌ eng/package-versioning.json not found."
+            echo "   Create this file in your repo. See the schema at:"
+            echo "   https://github.com/LayeredCraft/devops-templates/blob/main/eng/package-versioning.schema.json"
+            exit 1
+          fi
+
+      - name: Resolve version
+        id: version
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          from pathlib import Path
+
+          config = json.loads(Path("eng/package-versioning.json").read_text())
+
+          pkg = config["packages"].get("${{ inputs.packageId }}")
+          if not pkg:
+              raise SystemExit("❌ Package '${{ inputs.packageId }}' not found in eng/package-versioning.json")
+
+          strategy = pkg["strategy"]
+
+          if strategy == "single":
+              prefix = pkg["defaultVersionPrefix"]
+              sdk = ""
+
+          elif strategy == "by-profile":
+              profile_key = "${{ inputs.versionProfile }}"
+              if not profile_key:
+                  raise SystemExit("❌ versionProfile is required for by-profile packages")
+              profile = pkg["profiles"].get(profile_key)
+              if not profile:
+                  raise SystemExit(f"❌ Profile '{profile_key}' not found for package '${{ inputs.packageId }}'")
+              prefix = profile["versionPrefix"]
+              sdk = profile.get("dotnetSdk", "")
+
+          else:
+              raise SystemExit(f"❌ Unknown strategy: {strategy}")
+
+          version = f"{prefix}-preview.${{ github.run_number }}"
+          print(f"package_version={version}")
+          print(f"dotnet_sdk={sdk}")
+          PY
+
+      - name: Resolve SDK version
+        id: sdk
+        run: |
+          INPUT_SDK="${{ inputs.dotnetVersion }}"
+          JSON_SDK="${{ steps.version.outputs.dotnet_sdk }}"
+
+          if [ -n "$INPUT_SDK" ]; then
+            echo "dotnet_version=$INPUT_SDK" >> "$GITHUB_OUTPUT"
+          elif [ -n "$JSON_SDK" ]; then
+            echo "dotnet_version=$JSON_SDK" >> "$GITHUB_OUTPUT"
+          else
+            echo "❌ dotnetVersion not provided and no dotnetSdk defined in eng/package-versioning.json for this package/profile."
+            exit 1
+          fi
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ steps.sdk.outputs.dotnet_version }}
+
+      - name: Restore
+        run: dotnet restore ${{ inputs.solution }}
+
+      - name: Build
+        run: dotnet build ${{ inputs.solution }} --configuration Release --no-restore
+
+      - name: Test
+        if: inputs.hasTests == true
+        run: dotnet test ${{ inputs.solution }} --configuration Release --no-restore
+
+      - name: Pack
+        run: dotnet pack ${{ inputs.solution }} --configuration Release --no-build -o artifacts /p:Version=${{ steps.version.outputs.package_version }}
+
+      - name: Publish to NuGet
+        run: dotnet nuget push artifacts/**/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,141 @@
+name: Publish Release
+
+on:
+  workflow_call:
+    inputs:
+      solution:
+        description: "Solution file name"
+        required: true
+        type: string
+      packageId:
+        description: "NuGet package ID (must match a key in eng/package-versioning.json)"
+        required: true
+        type: string
+      versionProfile:
+        description: "Profile name for by-profile packages (e.g. net9)"
+        required: false
+        default: ""
+        type: string
+      hasTests:
+        description: "Run tests before publish"
+        required: false
+        default: true
+        type: boolean
+      dotnetVersion:
+        description: ".NET SDK version. Falls back to dotnetSdk from JSON profile if not provided."
+        required: false
+        default: ""
+        type: string
+    secrets:
+      NUGET_API_KEY:
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Validate manifest exists
+        run: |
+          if [ ! -f "eng/package-versioning.json" ]; then
+            echo "❌ eng/package-versioning.json not found."
+            echo "   Create this file in your repo. See the schema at:"
+            echo "   https://github.com/LayeredCraft/devops-templates/blob/main/eng/package-versioning.schema.json"
+            exit 1
+          fi
+
+      - name: Validate and resolve version
+        id: version
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          from pathlib import Path
+
+          tag = "${{ github.ref_name }}"
+          if not tag.startswith("v"):
+              raise SystemExit(f"❌ Tag '{tag}' must start with 'v' (e.g. v1.4.0)")
+          version = tag[1:]
+
+          config = json.loads(Path("eng/package-versioning.json").read_text())
+
+          pkg = config["packages"].get("${{ inputs.packageId }}")
+          if not pkg:
+              raise SystemExit("❌ Package '${{ inputs.packageId }}' not found in eng/package-versioning.json")
+
+          strategy = pkg["strategy"]
+
+          if strategy == "single":
+              expected = pkg["defaultVersionPrefix"]
+              sdk = ""
+
+          elif strategy == "by-profile":
+              profile_key = "${{ inputs.versionProfile }}"
+              if not profile_key:
+                  raise SystemExit("❌ versionProfile is required for by-profile packages")
+              profile = pkg["profiles"].get(profile_key)
+              if not profile:
+                  raise SystemExit(f"❌ Profile '{profile_key}' not found for package '${{ inputs.packageId }}'")
+              expected = profile["versionPrefix"]
+              sdk = profile.get("dotnetSdk", "")
+
+          else:
+              raise SystemExit(f"❌ Unknown strategy: {strategy}")
+
+          if version != expected:
+              raise SystemExit(
+                  f"❌ Tag version '{version}' does not match expected prefix '{expected}' "
+                  f"in eng/package-versioning.json for package '${{ inputs.packageId }}'"
+              )
+
+          print(f"package_version={version}")
+          print(f"dotnet_sdk={sdk}")
+          PY
+
+      - name: Resolve SDK version
+        id: sdk
+        run: |
+          INPUT_SDK="${{ inputs.dotnetVersion }}"
+          JSON_SDK="${{ steps.version.outputs.dotnet_sdk }}"
+
+          if [ -n "$INPUT_SDK" ]; then
+            echo "dotnet_version=$INPUT_SDK" >> "$GITHUB_OUTPUT"
+          elif [ -n "$JSON_SDK" ]; then
+            echo "dotnet_version=$JSON_SDK" >> "$GITHUB_OUTPUT"
+          else
+            echo "❌ dotnetVersion not provided and no dotnetSdk defined in eng/package-versioning.json for this package/profile."
+            exit 1
+          fi
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ steps.sdk.outputs.dotnet_version }}
+
+      - name: Restore
+        run: dotnet restore ${{ inputs.solution }}
+
+      - name: Build
+        run: dotnet build ${{ inputs.solution }} --configuration Release --no-restore
+
+      - name: Test
+        if: inputs.hasTests == true
+        run: dotnet test ${{ inputs.solution }} --configuration Release --no-restore
+
+      - name: Pack
+        run: dotnet pack ${{ inputs.solution }} --configuration Release --no-build -o artifacts /p:Version=${{ steps.version.outputs.package_version }}
+
+      - name: Publish to NuGet
+        run: dotnet nuget push artifacts/**/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/eng/package-versioning.schema.json
+++ b/eng/package-versioning.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "LayeredCraft Package Versioning",
+  "description": "Version manifest for LayeredCraft NuGet packages. Place at eng/package-versioning.json in each consuming repo.",
+  "type": "object",
+  "required": ["packages"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "packages": {
+      "type": "object",
+      "description": "Map of NuGet package ID to versioning config.",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Single version line for all builds.",
+            "required": ["strategy", "defaultVersionPrefix"],
+            "additionalProperties": false,
+            "properties": {
+              "strategy": {
+                "type": "string",
+                "const": "single"
+              },
+              "defaultVersionPrefix": {
+                "type": "string",
+                "description": "SemVer prefix, e.g. 1.4.0",
+                "pattern": "^\\d+\\.\\d+\\.\\d+$"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Multiple version lines selected via versionProfile.",
+            "required": ["strategy", "profiles"],
+            "additionalProperties": false,
+            "properties": {
+              "strategy": {
+                "type": "string",
+                "const": "by-profile"
+              },
+              "profiles": {
+                "type": "object",
+                "description": "Map of profile name (e.g. net9) to version config.",
+                "additionalProperties": {
+                  "type": "object",
+                  "required": ["versionPrefix"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "versionPrefix": {
+                      "type": "string",
+                      "description": "SemVer prefix for this profile, e.g. 9.0.0",
+                      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+                    },
+                    "dotnetSdk": {
+                      "type": "string",
+                      "description": "SDK version to use if dotnetVersion input not provided, e.g. 9.0.x"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/nuget-versioning-strategy.md
+++ b/nuget-versioning-strategy.md
@@ -1,0 +1,428 @@
+# NuGet Versioning & CI/CD Strategy (LayeredCraft)
+
+## Overview
+
+This strategy uses a **JSON-based version manifest** as the single source of truth for package versioning.
+
+It replaces all previous `PackageVersionPrefix` / MSBuild-based approaches.
+
+---
+
+# Core Design
+
+## Source of Truth
+
+All versioning is defined in each consuming repo at:
+
+```
+eng/package-versioning.json
+```
+
+`devops-templates` ships a JSON Schema at `eng/package-versioning.schema.json` that consumers reference for IDE validation and typo prevention.
+
+Example:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/LayeredCraft/devops-templates/main/eng/package-versioning.schema.json",
+  "packages": {
+    "LayeredCraft.StructuredLogging": {
+      "strategy": "single",
+      "defaultVersionPrefix": "1.4.0"
+    },
+    "LayeredCraft.EntityFrameworkCore.DynamoDB": {
+      "strategy": "by-profile",
+      "profiles": {
+        "net9": {
+          "versionPrefix": "9.0.0",
+          "dotnetSdk": "9.0.x"
+        },
+        "net10": {
+          "versionPrefix": "10.0.0",
+          "dotnetSdk": "10.0.x"
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+# Key Concepts
+
+## Strategies
+
+| Strategy     | Behavior |
+|--------------|----------|
+| `single`     | One version line for all builds |
+| `by-profile` | Multiple version lines, selected via `versionProfile` input |
+
+---
+
+## Important Rule
+
+> A single publish produces a single version.
+
+Even if you:
+- multi-target frameworks
+- test across multiple SDKs
+
+You still publish exactly one package version per run.
+
+For `by-profile` packages that publish multiple version lines (e.g. net9 + net10), the consuming caller defines **one job per profile**, running in parallel.
+
+---
+
+# Workflow Model
+
+## 1. PR Build
+
+- Uses existing `pr-build.yaml` — no changes needed
+- Matrix build across SDKs
+- Restore / build / test only
+- No versioning involved
+
+## 2. Publish Preview (main push)
+
+New file: `.github/workflows/publish-preview.yml`
+
+- Triggered by consumer caller on push to `main`
+- Validates `eng/package-versioning.json` exists (fail with clear error if missing)
+- Fails fast if `packageId` not found in JSON
+- Resolves version prefix from JSON:
+  - `single` → `defaultVersionPrefix`
+  - `by-profile` → `profiles[versionProfile].versionPrefix`
+- If `dotnetVersion` input not provided, falls back to `dotnetSdk` from JSON profile (only applicable to `by-profile`)
+- Publishes: `<prefix>-preview.<runNumber>`
+- No git tag created
+
+## 3. Publish Release (tag push)
+
+New file: `.github/workflows/publish-release.yml`
+
+- Triggered by consumer caller on tag push (`vX.Y.Z`)
+- Validates `eng/package-versioning.json` exists
+- Extracts version from tag
+- **Validates exact prefix match**: tag `v1.4.0` must match `defaultVersionPrefix: 1.4.0` exactly; tag `v9.0.0` must match `profiles.net9.versionPrefix: 9.0.0` exactly
+- Re-builds from tagged commit (clean build, no artifact promotion)
+- Publishes stable version
+- Creates git tag (already present from push event — no new tag needed)
+- Auto-creates GitHub Release with generated release notes
+
+## 4. Release Drafter
+
+- Out of scope for this implementation
+- Will maintain release notes and determine next intended version
+- Does NOT publish
+
+---
+
+# Reusable Workflow Inputs
+
+```yaml
+inputs:
+  solution:
+    type: string
+    required: true
+  packageId:
+    type: string
+    required: true
+  versionProfile:
+    type: string
+    default: ""
+  hasTests:
+    type: boolean
+    default: true
+  dotnetVersion:
+    type: string
+    default: ""       # Falls back to dotnetSdk from JSON profile if by-profile and not provided
+```
+
+---
+
+# Version Resolution (Preview)
+
+```yaml
+- name: Validate manifest exists
+  run: |
+    if [ ! -f "eng/package-versioning.json" ]; then
+      echo "❌ eng/package-versioning.json not found. Create it in the consuming repo."
+      exit 1
+    fi
+
+- name: Resolve version
+  id: version
+  run: |
+    python3 - <<'PY' >> "$GITHUB_OUTPUT"
+    import json
+    from pathlib import Path
+
+    config = json.loads(Path("eng/package-versioning.json").read_text())
+
+    pkg = config["packages"].get("${{ inputs.packageId }}")
+    if not pkg:
+        raise SystemExit(f"❌ Package '${{ inputs.packageId }}' not found in eng/package-versioning.json")
+
+    strategy = pkg["strategy"]
+
+    if strategy == "single":
+        prefix = pkg["defaultVersionPrefix"]
+        sdk = None
+
+    elif strategy == "by-profile":
+        profile_key = "${{ inputs.versionProfile }}"
+        if not profile_key:
+            raise SystemExit("❌ versionProfile is required for by-profile packages")
+        profile = pkg["profiles"].get(profile_key)
+        if not profile:
+            raise SystemExit(f"❌ Profile '{profile_key}' not found for package '${{ inputs.packageId }}'")
+        prefix = profile["versionPrefix"]
+        sdk = profile.get("dotnetSdk")
+
+    else:
+        raise SystemExit(f"❌ Unknown strategy: {strategy}")
+
+    version = f"{prefix}-preview.${{ github.run_number }}"
+    print(f"package_version={version}")
+    if sdk:
+        print(f"dotnet_sdk={sdk}")
+    PY
+```
+
+---
+
+# Version Validation (Release)
+
+```yaml
+- name: Validate version
+  run: |
+    python3 - <<'PY'
+    import json
+    from pathlib import Path
+
+    tag = "${{ github.ref_name }}"          # e.g. v1.4.0
+    if not tag.startswith("v"):
+        raise SystemExit(f"❌ Tag '{tag}' must start with 'v'")
+    version = tag[1:]                        # strip leading v
+
+    config = json.loads(Path("eng/package-versioning.json").read_text())
+    pkg = config["packages"].get("${{ inputs.packageId }}")
+    if not pkg:
+        raise SystemExit(f"❌ Package '${{ inputs.packageId }}' not found in eng/package-versioning.json")
+
+    strategy = pkg["strategy"]
+
+    if strategy == "single":
+        expected = pkg["defaultVersionPrefix"]
+    elif strategy == "by-profile":
+        profile_key = "${{ inputs.versionProfile }}"
+        expected = pkg["profiles"][profile_key]["versionPrefix"]
+    else:
+        raise SystemExit(f"❌ Unknown strategy: {strategy}")
+
+    if version != expected:
+        raise SystemExit(
+            f"❌ Tag version '{version}' does not match expected prefix '{expected}' "
+            f"from eng/package-versioning.json"
+        )
+
+    print(f"package_version={version}")
+    PY
+```
+
+---
+
+# Existing Workflow Changes
+
+| File | Action |
+|------|--------|
+| `package-build.yaml` | **Keep as-is** — used by consumers that have not yet migrated |
+| `pr-build.yaml` | No changes |
+| `publish-preview.yml` | **New file** |
+| `publish-release.yml` | **New file** |
+
+---
+
+# Example: Standard Package
+
+```json
+"LayeredCraft.StructuredLogging": {
+  "strategy": "single",
+  "defaultVersionPrefix": "1.4.0"
+}
+```
+
+Preview:
+```
+1.4.0-preview.12
+```
+
+Release:
+```
+v1.4.0
+```
+
+---
+
+# Example: Multi-Line Package (by-profile)
+
+```json
+"LayeredCraft.EntityFrameworkCore.DynamoDB": {
+  "strategy": "by-profile",
+  "profiles": {
+    "net9": { "versionPrefix": "9.0.0", "dotnetSdk": "9.0.x" },
+    "net10": { "versionPrefix": "10.0.0", "dotnetSdk": "10.0.x" }
+  }
+}
+```
+
+Consumer caller — two parallel jobs:
+
+```yaml
+jobs:
+  publish-net9:
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@main
+    with:
+      solution: MySolution.slnx
+      packageId: LayeredCraft.EntityFrameworkCore.DynamoDB
+      versionProfile: net9
+
+  publish-net10:
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@main
+    with:
+      solution: MySolution.slnx
+      packageId: LayeredCraft.EntityFrameworkCore.DynamoDB
+      versionProfile: net10
+```
+
+Results:
+```
+9.0.0-preview.12
+10.0.0-preview.12
+```
+
+---
+
+# Caller Workflows
+
+## PR Build (unchanged)
+
+```yaml
+jobs:
+  build:
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yml@main
+    with:
+      solution: MySolution.slnx
+      dotnetVersion: |
+        9.0.x
+        10.0.x
+```
+
+---
+
+## Publish Preview (new)
+
+```yaml
+# Triggers on push to main
+jobs:
+  publish:
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@main
+    with:
+      solution: MySolution.slnx
+      packageId: LayeredCraft.StructuredLogging
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+```
+
+---
+
+## Publish Release (new)
+
+```yaml
+# Triggers on tag push vX.Y.Z
+jobs:
+  publish:
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@main
+    with:
+      solution: MySolution.slnx
+      packageId: LayeredCraft.StructuredLogging
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+```
+
+---
+
+# JSON Schema (devops-templates ships this)
+
+Location in devops-templates: `eng/package-versioning.schema.json`
+
+Consumers reference it via `$schema` in their `eng/package-versioning.json` for IDE validation.
+
+---
+
+# Implementation Plan
+
+## Phase 1: devops-templates repo
+
+1. Create `eng/package-versioning.schema.json`
+2. Create `.github/workflows/publish-preview.yml`
+3. Create `.github/workflows/publish-release.yml`
+
+## Phase 2: Pilot consumer (LayeredCraft.StructuredLogging repo)
+
+1. Create `eng/package-versioning.json` with `single` strategy entry
+2. Add publish-preview caller workflow (trigger: push to main)
+3. Add publish-release caller workflow (trigger: tag push)
+4. Remove or disable `package-build.yaml` usage in that repo
+
+## Phase 3: Remaining packages
+
+- Migrate each package repo
+- `by-profile` packages define parallel jobs in caller
+
+---
+
+# Key Decisions
+
+| Decision | Choice | Reason |
+|----------|--------|--------|
+| Preview tags | No | Preview builds are ephemeral |
+| Release validation | Exact prefix match | Prevents accidental version mismatch |
+| GitHub Release creation | Auto in publish-release | Mirrors current behavior |
+| Release trigger | Separate caller per event | Clean separation of concerns |
+| JSON location | Per consuming repo | Each repo owns its version |
+| SDK from JSON | Optional fallback | Caller can override; JSON is default for by-profile |
+| Missing package | Fail fast | Clear error surfaced immediately |
+| File missing | Fail with helpful error | Guides consumer to create the file |
+| skip-duplicate | Kept | Idempotent, safe to retry |
+| package-build.yaml | Keep (not deleted) | Backwards-compat during migration |
+| Release Drafter | Out of scope | Separate concern, add later |
+| JSON Schema | Ship in devops-templates | IDE validation, prevents typos |
+
+---
+
+# Benefits
+
+- Fully explicit version control
+- No MSBuild coupling
+- No EF-specific logic
+- Supports multiple version lines cleanly
+- Works with matrix builds
+- Scales across all LayeredCraft packages
+- JSON Schema provides IDE-level validation for consumers
+
+---
+
+# Final Recommendation
+
+Adopt the JSON manifest as the **only version source**.
+
+- Do NOT use `PackageVersionPrefix`
+- Do NOT infer from TFM or SDK
+- Always resolve version from JSON
+
+This keeps versioning:
+- explicit
+- centralized
+- predictable


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary

Introduces a JSON-based NuGet versioning strategy to replace the MSBuild `VersionPrefix` approach. Adds two new reusable workflows (`publish-preview.yml` and `publish-release.yml`) and a JSON Schema that consuming repos reference as their version manifest.

- `publish-preview.yml` — triggers on push to `main`, resolves version from `eng/package-versioning.json`, publishes `<prefix>-preview.<runNumber>` to NuGet
- `publish-release.yml` — triggers on tag push (`v*`), validates tag against JSON manifest (exact match), publishes stable version and creates a GitHub Release
- `eng/package-versioning.schema.json` — JSON Schema for IDE validation in consuming repos
- `nuget-versioning-strategy.md` — full strategy document with design decisions

Supports two strategies: `single` (one version line) and `by-profile` (multiple version lines per .NET SDK profile).

---

## ✅ Checklist

- [ ] My changes build cleanly
- [ ] I've added/updated relevant tests
- [ ] I've added/updated documentation or README
- [ ] I've followed the coding style for this project
- [ ] I've tested the changes locally (if applicable)

---

## 🧪 Related Issues or PRs

Closes #...

---

## 💬 Notes for Reviewers

This PR must be merged before the companion PR in `structured-logging` can be tested — the caller workflows there reference `@main` on this repo.

Key design decisions documented in `nuget-versioning-strategy.md`:
- `package-build.yaml` is kept (not deleted) for backwards compatibility during migration
- Release validation is an exact prefix match — tag `v1.4.0` must equal `defaultVersionPrefix: 1.4.0`
- `dotnetSdk` in JSON is an optional fallback if `dotnetVersion` input is not provided by the caller