### PR TITLE
fix(ci): stamp build outputs with publish version

### DIFF
--- a/.github/workflows/package-build.yaml
+++ b/.github/workflows/package-build.yaml
@@ -34,14 +34,14 @@ jobs:
         run: dotnet restore
 
       - name: Build
-        run: dotnet build --configuration Release --no-restore
+        run: dotnet build --configuration Release --no-restore /p:Version=${{ env.VERSION }} /p:InformationalVersion=${{ env.VERSION }}
 
       - name: Test Code
         if: inputs.hasTests == true
         run: dotnet test --no-restore
 
       - name: Pack
-        run: dotnet pack --configuration Release -o artifacts --no-build /p:Version=${{ env.VERSION }}
+        run: dotnet pack --configuration Release -o artifacts --no-build /p:Version=${{ env.VERSION }} /p:InformationalVersion=${{ env.VERSION }}
 
       - name: Publish to Nuget
         run: dotnet nuget push **/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -74,14 +74,14 @@ jobs:
         run: dotnet restore ${{ inputs.solution }}
 
       - name: Build
-        run: dotnet build ${{ inputs.solution }} --configuration Release --no-restore
+        run: dotnet build ${{ inputs.solution }} --configuration Release --no-restore /p:Version=${{ steps.version.outputs.package_version }} /p:InformationalVersion=${{ steps.version.outputs.package_version }}
 
       - name: Test
         if: inputs.hasTests == true
         run: dotnet test --solution ${{ inputs.solution }} --configuration Release --no-restore
 
       - name: Pack
-        run: dotnet pack ${{ inputs.solution }} --configuration Release --no-build -o artifacts /p:Version=${{ steps.version.outputs.package_version }}
+        run: dotnet pack ${{ inputs.solution }} --configuration Release --no-build -o artifacts /p:Version=${{ steps.version.outputs.package_version }} /p:InformationalVersion=${{ steps.version.outputs.package_version }}
 
       - name: Publish to NuGet
         run: dotnet nuget push artifacts/**/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -45,14 +45,14 @@ jobs:
         run: dotnet restore ${{ inputs.solution }}
 
       - name: Build
-        run: dotnet build ${{ inputs.solution }} --configuration Release --no-restore
+        run: dotnet build ${{ inputs.solution }} --configuration Release --no-restore /p:Version=${{ steps.version.outputs.package_version }} /p:InformationalVersion=${{ steps.version.outputs.package_version }}
 
       - name: Test
         if: inputs.hasTests == true
         run: dotnet test --solution ${{ inputs.solution }} --configuration Release --no-restore
 
       - name: Pack
-        run: dotnet pack ${{ inputs.solution }} --configuration Release --no-build -o artifacts /p:Version=${{ steps.version.outputs.package_version }}
+        run: dotnet pack ${{ inputs.solution }} --configuration Release --no-build -o artifacts /p:Version=${{ steps.version.outputs.package_version }} /p:InformationalVersion=${{ steps.version.outputs.package_version }}
 
       - name: Publish to NuGet
         run: dotnet nuget push artifacts/**/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## Summary
- pass version metadata to `dotnet build` in all publish/build workflows so compiled assemblies are stamped with the resolved package version
- keep `dotnet pack --no-build` aligned with the same `Version` and `InformationalVersion` properties for deterministic package metadata
- fixes source generator scenarios that read assembly metadata and were seeing `1.0.0.0` despite correct NuGet package versions