### PR TITLE
ci(github): skip draft PR workflows

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -97,6 +97,7 @@ permissions:
   
 jobs:
   deploy:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     env:
       outputPath: ${{ github.workspace }}/${{ inputs.outputPath }}

--- a/.github/workflows/package-build.yaml
+++ b/.github/workflows/package-build.yaml
@@ -12,6 +12,7 @@ on:
         type: boolean
 jobs:
   build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -113,6 +113,7 @@ permissions:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -31,6 +31,7 @@ permissions:
 
 jobs:
   publish:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -25,6 +25,7 @@ permissions:
 
 jobs:
   publish:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   autolabel:
     runs-on: ubuntu-latest
-    if: inputs.event_name == 'pull_request' && inputs.pr_draft == false
+    if: inputs.event_name == 'pull_request' && inputs.pr_draft == false && github.event.pull_request.draft != true
 
     steps:
       - uses: release-drafter/release-drafter/autolabeler@v7

--- a/README.md
+++ b/README.md
@@ -27,6 +27,27 @@ jobs:
       runCdk: true
 ```
 
+## Draft Pull Requests
+
+Draft pull requests run only lightweight feedback workflows. `pr-title-check.yml` can still run on draft PRs, but workflows that build, deploy, publish packages, tag commits, or update release metadata skip draft PRs.
+
+The guarded reusable workflows are:
+
+- `.github/workflows/pr-build.yaml`
+- `.github/workflows/build-deploy.yaml`
+- `.github/workflows/package-build.yaml`
+- `.github/workflows/publish-preview.yml`
+- `.github/workflows/publish-release.yml`
+- `.github/workflows/release-drafter.yml` autolabel job
+
+When a PR is marked ready for review, callers should trigger on `ready_for_review` so skipped checks run:
+
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+```
+
 ## Permissions
 When using these shared workflows, make sure to enable Read and Write permissions for your GitHub Actions. This is necessary for the workflows to access and modify the repository contents as needed.
 


### PR DESCRIPTION
## Summary

Guard reusable workflows so draft pull requests do not run build, deploy, publish, tag, or release metadata jobs. This keeps draft PRs lightweight while still allowing cheap feedback like the PR title check.

## Changes

- Added draft PR job guards to PR build, build/deploy, package build, publish preview, and publish release workflows.
- Hardened the Release Drafter autolabel job so it skips draft PRs even if callers omit the `pr_draft` input.
- Documented the draft PR policy and recommended `ready_for_review` trigger in `README.md`.

## Validation

- Ran `git diff --check`.
- Parsed workflow YAML files with Ruby `YAML.load_file`.

## Notes for Reviewers

The guard only skips jobs for draft `pull_request` events. Push, release, and manual caller events continue to run as before.
