### PR TITLE
feat(pr-build): add stackName input to filter CDK synth to specific stacks

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -102,6 +102,10 @@ on:
         required: false
         default: true
         type: boolean
+      stackName:
+        description: "Base name of the AWS CDK stack (e.g. my-app-stack). When provided, synth targets only my-app-stack-dev and my-app-stack-prod. When omitted, all stacks are synthesized."
+        required: false
+        type: string
       functions:
         description: "JSON array of Lambda functions to build"
         required: false
@@ -449,4 +453,9 @@ jobs:
           TMP_WEBHOOK_SECRET: ${{ secrets.TMP_WEBHOOK_SECRET }}
           OPENAI_APIKEY: ${{ secrets.OPENAI_APIKEY }}
           OPENAI_ORGANIZATION: ${{ secrets.OPENAI_ORGANIZATION }}
-        run: npx aws-cdk synth
+        run: |
+          if [ -n "${{ inputs.stackName }}" ]; then
+            npx aws-cdk synth ${{ inputs.stackName }}-dev ${{ inputs.stackName }}-prod
+          else
+            npx aws-cdk synth
+          fi


### PR DESCRIPTION
## Summary

Adds a `stackName` input to `pr-build.yaml`, mirroring the pattern already used in `build-deploy.yaml`. When provided, CDK synth targets only `{stackName}-dev` and `{stackName}-prod` instead of all stacks. Omitting `stackName` retains the existing behavior.

## Motivation

Monorepos with a single CDK project containing multiple independent product stacks (e.g. `disney-trivia-skill-stack` and `disney-trivia-web-stack` in `Trivia.Platform.Infra`) need each PR build workflow to synth only its own stacks. Without this, the skill PR build fails when web assets don't exist, and the web PR build fails when skill Lambda zips don't exist.

## Changes

- Added `stackName` input (optional, no default)
- `Run AWS CDK Synth` step: when `stackName` is set, runs `npx aws-cdk synth {stackName}-dev {stackName}-prod`; when omitted, runs `npx aws-cdk synth` (unchanged behavior)

## Backward Compatible

All existing callers that don't pass `stackName` continue to work exactly as before.