### PR TITLE
feat(pr-build): pass cdkSynthTarget context to CDK synth

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -419,7 +419,7 @@ jobs:
         run: |
           SYNTH_TARGET_ARG=""
           if [ -n "${{ inputs.stackName }}" ]; then
-            SYNTH_TARGET_ARG="--context cdkSynthTarget=${{ inputs.stackName }}"
+            SYNTH_TARGET_ARG="--context stackGroup=${{ inputs.stackName }}"
           fi
           npx aws-cdk deploy --require-approval never --context releaseVersion=${{ env.RELEASE_VERSION }} $SYNTH_TARGET_ARG ${{ env.DEPLOY_ENV }}
 

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -416,7 +416,12 @@ jobs:
           TMP_WEBHOOK_SECRET: ${{ secrets.TMP_WEBHOOK_SECRET }}
           OPENAI_APIKEY: ${{ secrets.OPENAI_APIKEY }}
           OPENAI_ORGANIZATION: ${{ secrets.OPENAI_ORGANIZATION }}
-        run: npx aws-cdk deploy --require-approval never --context releaseVersion=${{ env.RELEASE_VERSION }} ${{ env.DEPLOY_ENV }}
+        run: |
+          SYNTH_TARGET_ARG=""
+          if [ -n "${{ inputs.stackName }}" ]; then
+            SYNTH_TARGET_ARG="--context cdkSynthTarget=${{ inputs.stackName }}"
+          fi
+          npx aws-cdk deploy --require-approval never --context releaseVersion=${{ env.RELEASE_VERSION }} $SYNTH_TARGET_ARG ${{ env.DEPLOY_ENV }}
 
       - name: Restore Integration Test Dependencies
         if: inputs.integrationTestSolution != '' && !startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -102,6 +102,10 @@ on:
         required: false
         default: true
         type: boolean
+      stackName:
+        description: "Base name of the AWS CDK stack (e.g. my-app-stack). When provided, synth targets only my-app-stack-dev and my-app-stack-prod. When omitted, all stacks are synthesized."
+        required: false
+        type: string
       functions:
         description: "JSON array of Lambda functions to build"
         required: false
@@ -449,4 +453,9 @@ jobs:
           TMP_WEBHOOK_SECRET: ${{ secrets.TMP_WEBHOOK_SECRET }}
           OPENAI_APIKEY: ${{ secrets.OPENAI_APIKEY }}
           OPENAI_ORGANIZATION: ${{ secrets.OPENAI_ORGANIZATION }}
-        run: npx aws-cdk synth
+        run: |
+          if [ -n "${{ inputs.stackName }}" ]; then
+            npx aws-cdk synth ${{ inputs.stackName }}-dev ${{ inputs.stackName }}-prod
+          else
+            npx aws-cdk synth
+          fi

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -455,7 +455,7 @@ jobs:
           OPENAI_ORGANIZATION: ${{ secrets.OPENAI_ORGANIZATION }}
         run: |
           if [ -n "${{ inputs.stackName }}" ]; then
-            npx aws-cdk synth ${{ inputs.stackName }}-dev ${{ inputs.stackName }}-prod
+            npx aws-cdk synth --context cdkSynthTarget=${{ inputs.stackName }} ${{ inputs.stackName }}-dev ${{ inputs.stackName }}-prod
           else
             npx aws-cdk synth
           fi

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -455,7 +455,7 @@ jobs:
           OPENAI_ORGANIZATION: ${{ secrets.OPENAI_ORGANIZATION }}
         run: |
           if [ -n "${{ inputs.stackName }}" ]; then
-            npx aws-cdk synth --context cdkSynthTarget=${{ inputs.stackName }} ${{ inputs.stackName }}-dev ${{ inputs.stackName }}-prod
+            npx aws-cdk synth --context stackGroup=${{ inputs.stackName }} ${{ inputs.stackName }}-dev ${{ inputs.stackName }}-prod
           else
             npx aws-cdk synth
           fi


### PR DESCRIPTION
## Summary

Small follow-up to #25. Passes `--context cdkSynthTarget={stackName}` to `cdk synth` alongside the stack name filter, allowing the CDK app's `Program.cs` to guard which stacks it constructs based on the current build context.

## Problem

Even with stack name filtering (`npx aws-cdk synth skill-stack-dev skill-stack-prod`), CDK still executes the entire app entrypoint and constructs all stacks in memory. Constructs that validate asset paths at construction time (e.g. `LambdaFunctionConstruct`) fail immediately when their assets don't exist — even for stacks that aren't being synthesized.

## Fix

Pass `--context cdkSynthTarget={stackName}` so `Program.cs` can read `app.Node.TryGetContext("cdkSynthTarget")` and conditionally skip constructing stacks whose assets aren't present. Backward compatible: no context when `stackName` is omitted.