### PR TITLE
feat(github): use run_id for release versioning

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -386,7 +386,8 @@ jobs:
           if [[ "${{ github.ref }}" == refs/tags/* ]]; then
             echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
           else
-            echo "RELEASE_VERSION=${{ github.run_id }}" >> $GITHUB_ENV
+            BASE_VERSION=$(date +'%Y.%m.%d')
+            echo "RELEASE_VERSION=v${BASE_VERSION}.${{ github.run_id }}" >> $GITHUB_ENV
           fi
 
           echo "Release Version: $RELEASE_VERSION"

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -384,11 +384,9 @@ jobs:
         id: set-release-version
         run: |
           if [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV  # Extract tag name as release version
+            echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
           else
-            BUILD_NUMBER=${{ github.run_number }}
-            BASE_VERSION=$(date +'%Y.%m.%d')
-            echo "RELEASE_VERSION=v${BASE_VERSION}.${BUILD_NUMBER}" >> $GITHUB_ENV
+            echo "RELEASE_VERSION=${{ github.run_id }}" >> $GITHUB_ENV
           fi
 
           echo "Release Version: $RELEASE_VERSION"


### PR DESCRIPTION
## Summary

Replaces date+run_number release tag format with github.run_id. The run_id is globally unique and monotonically increasing across all workflow runs in a repo, eliminating tag ordering conflicts when multiple deploy workflows run for different components in the same repo.

## Changes

Before: `RELEASE_VERSION=v${date}.${run_number}`
After: `RELEASE_VERSION=${{ github.run_id }}`

## Problem solved

When a repo has multiple deploy workflows (e.g. four in trivia-platform), each generates a tag based on date+run_number. Since run_number resets per workflow, interleaved tags have no consistent ordering — Trivia Manager's deploy gate rejects versions it considers older than the most recently deployed one, causing false rejections.

run_id is always unique and always increasing regardless of which workflow generated it.

## Validation

Companion PRs pointing to this branch for integration testing:
- ncipollina/trivia-platform#197
- ncipollina/trivia-manager#198

Merge after confirming both consumer repos work correctly.