### PR TITLE
feat(ci): add multi-version EF build configuration support

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -174,7 +174,7 @@ jobs:
           SOLUTION="${{ inputs.solution }}"
           SOLUTION_ARGS=()
           [ -n "$SOLUTION" ] && SOLUTION_ARGS+=(--solution "$SOLUTION")
-          dotnet test "${SOLUTION_ARGS[@]}" --no-restore --configuration Release
+          dotnet test "${SOLUTION_ARGS[@]}" --no-restore --configuration "${{ inputs.buildConfiguration }}"
 
       - name: Test Code with Legacy Coverage
         if: env.NEEDS_DOTNET == 'true' && inputs.hasTests == true && inputs.useMtpRunner == false && inputs.enableCodeCoverage == true
@@ -186,7 +186,7 @@ jobs:
             --collect:"XPlat Code Coverage" \
             --results-directory ./coverage \
             --logger trx \
-            --configuration Release \
+            --configuration "${{ inputs.buildConfiguration }}" \
             -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=${{ inputs.coverageReportFormats }}
 
       - name: Test Code with MTP Coverage
@@ -202,7 +202,7 @@ jobs:
 
           dotnet test "${SOLUTION_ARGS[@]}" --no-restore \
             --results-directory ./coverage \
-            --configuration Release \
+            --configuration "${{ inputs.buildConfiguration }}" \
             --report-xunit-trx \
             --coverage \
             $COVERAGE_SETTINGS \

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Restore Dependencies
         if: env.NEEDS_DOTNET == 'true'
-        run: dotnet restore ${{ inputs.solution }} --configuration "${{ inputs.buildConfiguration }}"
+        run: dotnet restore ${{ inputs.solution }} -p:Configuration="${{ inputs.buildConfiguration }}"
 
       - name: Build Code
         if: env.NEEDS_DOTNET == 'true'

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -1,5 +1,5 @@
 name: PR Build
-
+# Reusable workflow — called by consumer repos on pull_request events.
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Restore Dependencies
         if: env.NEEDS_DOTNET == 'true'
-        run: dotnet restore ${{ inputs.solution }}
+        run: dotnet restore ${{ inputs.solution }} --configuration "${{ inputs.buildConfiguration }}"
 
       - name: Build Code
         if: env.NEEDS_DOTNET == 'true'

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -1,5 +1,5 @@
 name: PR Build
-# Reusable workflow — called by consumer repos on pull_request events.
+# Reusable workflow - called by consumer repos on pull_request events.
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -166,7 +166,7 @@ jobs:
 
       - name: Build Code
         if: env.NEEDS_DOTNET == 'true'
-        run: dotnet build ${{ inputs.solution }} --configuration ${{ inputs.buildConfiguration }} --no-restore
+        run: dotnet build ${{ inputs.solution }} --configuration "${{ inputs.buildConfiguration }}" --no-restore
 
       - name: Test Code
         if: env.NEEDS_DOTNET == 'true' && inputs.hasTests == true && inputs.enableCodeCoverage == false
@@ -241,7 +241,7 @@ jobs:
 
       - name: Build and Publish Blazor WebAssembly
         if: env.NEEDS_DOTNET == 'true' && inputs.webPath != ''
-        run: dotnet publish ${{ inputs.webPath }} --configuration ${{ inputs.buildConfiguration }} --no-restore --output ${{ env.outputPath }}
+        run: dotnet publish ${{ inputs.webPath }} --configuration "${{ inputs.buildConfiguration }}" --no-restore --output ${{ env.outputPath }}
 
       - name: Install jq
         if: inputs.functions != '[]' || inputs.spaSites != '[]'
@@ -259,7 +259,7 @@ jobs:
             ZIP_PATH="${{ env.outputPath }}/${NAME}.zip"
           
             echo "Packaging $NAME from FUNC_PATH..."
-            dotnet tool run dotnet-lambda package -pl "$FUNC_PATH" --configuration ${{ inputs.buildConfiguration }} --no-restore --framework ${{ inputs.lambdaRuntimeVersion }} --output-package "$ZIP_PATH"
+            dotnet tool run dotnet-lambda package -pl "$FUNC_PATH" --configuration "${{ inputs.buildConfiguration }}" --no-restore --framework ${{ inputs.lambdaRuntimeVersion }} --output-package "$ZIP_PATH"
           
             echo "Packaged: $ZIP_PATH"
           done

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -75,7 +75,7 @@ jobs:
           dotnet-version: ${{ inputs.dotnetVersion }}
 
       - name: Restore
-        run: dotnet restore ${{ inputs.solution }}
+        run: dotnet restore ${{ inputs.solution }} -p:Configuration="${{ inputs.buildConfiguration }}"
 
       - name: Build
         run: dotnet build ${{ inputs.solution }} --configuration "${{ inputs.buildConfiguration }}" --no-restore /p:Version=${{ steps.version.outputs.package_version }}

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -21,6 +21,16 @@ on:
         required: false
         default: true
         type: boolean
+      buildConfiguration:
+        description: "Build configuration (e.g. 'Release EF10'). Defaults to 'Release'."
+        required: false
+        default: "Release"
+        type: string
+      drafterConfig:
+        description: "Release Drafter config file name (e.g. release-drafter-ef10.yml)."
+        required: false
+        default: "release-drafter.yml"
+        type: string
     secrets:
       NUGET_API_KEY:
         required: true
@@ -37,19 +47,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Validate release-drafter config exists
-        run: |
-          if [ ! -f ".github/release-drafter.yml" ]; then
-            echo "❌ .github/release-drafter.yml not found."
-            echo "   This file is required for preview version resolution."
-            exit 1
-          fi
-
       - name: Resolve next version via Release Drafter
         id: release-drafter
         uses: release-drafter/release-drafter@v7
         with:
-          config-name: release-drafter.yml
+          config-name: ${{ inputs.drafterConfig }}
           dry-run: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -60,7 +62,7 @@ jobs:
         run: |
           resolved="${{ steps.release-drafter.outputs.resolved_version }}"
           if [[ -z "$resolved" ]]; then
-            echo "::error::Release Drafter returned an empty resolved_version. Ensure .github/release-drafter.yml is configured correctly."
+            echo "::error::Release Drafter returned an empty resolved_version. Ensure .github/${{ inputs.drafterConfig }} is configured correctly."
             exit 1
           fi
           base="${resolved%%-*}"
@@ -76,14 +78,14 @@ jobs:
         run: dotnet restore ${{ inputs.solution }}
 
       - name: Build
-        run: dotnet build ${{ inputs.solution }} --configuration Release --no-restore /p:Version=${{ steps.version.outputs.package_version }}
+        run: dotnet build ${{ inputs.solution }} --configuration "${{ inputs.buildConfiguration }}" --no-restore /p:Version=${{ steps.version.outputs.package_version }}
 
       - name: Test
         if: inputs.hasTests == true
-        run: dotnet test --solution ${{ inputs.solution }} --configuration Release --no-build
+        run: dotnet test --solution ${{ inputs.solution }} --configuration "${{ inputs.buildConfiguration }}" --no-build
 
       - name: Pack
-        run: dotnet pack ${{ inputs.solution }} --configuration Release --no-build -o artifacts /p:Version=${{ steps.version.outputs.package_version }}
+        run: dotnet pack ${{ inputs.solution }} --configuration "${{ inputs.buildConfiguration }}" --no-build -o artifacts /p:Version=${{ steps.version.outputs.package_version }}
 
       - name: Publish to NuGet
         run: dotnet nuget push artifacts/**/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -47,7 +47,11 @@ jobs:
             echo "dotnet_version=${MAJOR}.0.x"      >> "$GITHUB_OUTPUT"
           else
             echo "configuration=${{ inputs.buildConfiguration }}" >> "$GITHUB_OUTPUT"
-            echo "dotnet_version=${{ inputs.dotnetVersion }}"     >> "$GITHUB_OUTPUT"
+            {
+              echo "dotnet_version<<EOF"
+              echo "${{ inputs.dotnetVersion }}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: true
         type: boolean
+      buildConfiguration:
+        description: "Build configuration. When 'auto', derived from release tag (vN.* → Release EFN)."
+        required: false
+        default: "Release"
+        type: string
     secrets:
       NUGET_API_KEY:
         required: true
@@ -24,36 +29,53 @@ permissions:
   contents: write
 
 jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      configuration: ${{ steps.cfg.outputs.configuration }}
+      dotnet_version: ${{ steps.cfg.outputs.dotnet_version }}
+      version: ${{ steps.cfg.outputs.version }}
+    steps:
+      - name: Resolve from tag
+        id: cfg
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          if [ "${{ inputs.buildConfiguration }}" = "auto" ]; then
+            MAJOR="${VERSION%%.*}"
+            echo "configuration=Release EF${MAJOR}" >> "$GITHUB_OUTPUT"
+            echo "dotnet_version=${MAJOR}.0.x"      >> "$GITHUB_OUTPUT"
+          else
+            echo "configuration=${{ inputs.buildConfiguration }}" >> "$GITHUB_OUTPUT"
+            echo "dotnet_version=${{ inputs.dotnetVersion }}"     >> "$GITHUB_OUTPUT"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
   publish:
+    needs: [resolve]
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v5
 
-      - name: Resolve version from tag
-        id: version
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          echo "package_version=${TAG#v}" >> "$GITHUB_OUTPUT"
-
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ inputs.dotnetVersion }}
+          dotnet-version: ${{ needs.resolve.outputs.dotnet_version }}
 
       - name: Restore
         run: dotnet restore ${{ inputs.solution }}
 
       - name: Build
-        run: dotnet build ${{ inputs.solution }} --configuration Release --no-restore /p:Version=${{ steps.version.outputs.package_version }} /p:InformationalVersion=${{ steps.version.outputs.package_version }}
+        run: dotnet build ${{ inputs.solution }} --configuration "${{ needs.resolve.outputs.configuration }}" --no-restore /p:Version=${{ needs.resolve.outputs.version }} /p:InformationalVersion=${{ needs.resolve.outputs.version }}
 
       - name: Test
         if: inputs.hasTests == true
-        run: dotnet test --solution ${{ inputs.solution }} --no-build --configuration Release --no-restore
+        run: dotnet test --solution ${{ inputs.solution }} --no-build --configuration "${{ needs.resolve.outputs.configuration }}" --no-restore
 
       - name: Pack
-        run: dotnet pack ${{ inputs.solution }} --configuration Release --no-build -o artifacts /p:Version=${{ steps.version.outputs.package_version }} /p:InformationalVersion=${{ steps.version.outputs.package_version }}
+        run: dotnet pack ${{ inputs.solution }} --configuration "${{ needs.resolve.outputs.configuration }}" --no-build -o artifacts /p:Version=${{ needs.resolve.outputs.version }} /p:InformationalVersion=${{ needs.resolve.outputs.version }}
 
       - name: Publish to NuGet
         run: dotnet nuget push artifacts/**/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -65,7 +65,7 @@ jobs:
           dotnet-version: ${{ needs.resolve.outputs.dotnet_version }}
 
       - name: Restore
-        run: dotnet restore ${{ inputs.solution }}
+        run: dotnet restore ${{ inputs.solution }} -p:Configuration="${{ needs.resolve.outputs.configuration }}"
 
       - name: Build
         run: dotnet build ${{ inputs.solution }} --configuration "${{ needs.resolve.outputs.configuration }}" --no-restore /p:Version=${{ needs.resolve.outputs.version }} /p:InformationalVersion=${{ needs.resolve.outputs.version }}


### PR DESCRIPTION
## Summary

- Add `buildConfiguration` input (default `"Release"`) to `pr-build.yaml`, `publish-preview.yml`, and `publish-release.yml` so callers can pass named configurations like `"Debug EF10"` or `"Release EF11"`
- Add `drafterConfig` input to `publish-preview.yml` so callers can specify a per-version release drafter config
- Add `buildConfiguration: auto` mode to `publish-release.yml` — derives `Release EFN` configuration and `N.0.x` SDK version from the release tag (e.g. `v11.2.0` → `Release EF11` + `11.0.x`)
- Fix three hardcoded `--configuration Release` flags in `pr-build.yaml` test steps to use `${{ inputs.buildConfiguration }}`

## Test plan

- [ ] PR build passes on this branch
- [ ] Caller repo can pass `buildConfiguration: "Debug EF10"` and `buildConfiguration: "Debug EF11"` in a matrix and both build/test correctly
- [ ] `publish-preview.yml` passes `drafterConfig` through to Release Drafter
- [ ] `publish-release.yml` with `buildConfiguration: auto` resolves correct configuration and SDK from tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)