### PR TITLE
ci(github): use NuGet OIDC login for publishing

### DIFF
--- a/.github/actions/nuget-push/action.yml
+++ b/.github/actions/nuget-push/action.yml
@@ -1,0 +1,30 @@
+name: NuGet Push
+description: Exchanges a GitHub OIDC token for a temporary NuGet API key and pushes packed artifacts.
+
+inputs:
+  nuget_user:
+    description: "NuGet.org username of the trusted publisher policy creator."
+    required: true
+  artifact_name:
+    description: "Name of the artifact containing the .nupkg files."
+    required: false
+    default: "nuget-packages"
+
+runs:
+  using: composite
+  steps:
+    - name: NuGet Login (OIDC)
+      uses: NuGet/login@v1
+      id: login
+      with:
+        user: ${{ inputs.nuget_user }}
+
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: artifacts
+
+    - name: Push to NuGet
+      shell: bash
+      run: dotnet nuget push artifacts/**/*.nupkg -k "${{ steps.login.outputs.NUGET_API_KEY }}" -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -31,12 +31,6 @@ on:
         required: false
         default: "release-drafter.yml"
         type: string
-    secrets:
-      NUGET_API_KEY:
-        required: false
-      NUGET_USER:
-        required: false
-
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -31,11 +31,6 @@ on:
         required: false
         default: "release-drafter.yml"
         type: string
-      nuget_api_key:
-        description: "NuGet API key. OIDC callers pass this; non-OIDC callers rely on NUGET_API_KEY secret."
-        required: false
-        default: ""
-        type: string
 permissions:
   contents: write
   pull-requests: write
@@ -88,5 +83,8 @@ jobs:
       - name: Pack
         run: dotnet pack ${{ inputs.solution }} --configuration "${{ inputs.buildConfiguration }}" --no-build -o artifacts /p:Version=${{ steps.version.outputs.package_version }}
 
-      - name: Publish to NuGet
-        run: dotnet nuget push artifacts/**/*.nupkg -k "${{ inputs.nuget_api_key }}" -s https://api.nuget.org/v3/index.json --skip-duplicate
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-packages
+          path: artifacts/**/*.nupkg

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -31,18 +31,16 @@ on:
         required: false
         default: "release-drafter.yml"
         type: string
-      nuget_api_key:
-        description: "NuGet API key obtained via OIDC in the caller. Falls back to NUGET_API_KEY secret."
-        required: false
-        default: ""
-        type: string
     secrets:
       NUGET_API_KEY:
+        required: false
+      NUGET_USER:
         required: false
 
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   publish:
@@ -92,12 +90,15 @@ jobs:
       - name: Pack
         run: dotnet pack ${{ inputs.solution }} --configuration "${{ inputs.buildConfiguration }}" --no-build -o artifacts /p:Version=${{ steps.version.outputs.package_version }}
 
-      - name: Mask NuGet API key
-        if: inputs.nuget_api_key != ''
-        run: echo "::add-mask::${{ inputs.nuget_api_key }}"
+      - name: NuGet Login (OIDC)
+        if: secrets.NUGET_USER != ''
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
 
       - name: Publish to NuGet
         run: |
-          KEY="${{ inputs.nuget_api_key }}"
+          KEY="${{ steps.login.outputs.NUGET_API_KEY }}"
           if [ -z "$KEY" ]; then KEY="${{ secrets.NUGET_API_KEY }}"; fi
           dotnet nuget push artifacts/**/*.nupkg -k "$KEY" -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -31,10 +31,14 @@ on:
         required: false
         default: "release-drafter.yml"
         type: string
+      nuget_api_key:
+        description: "NuGet API key. OIDC callers pass this; non-OIDC callers rely on NUGET_API_KEY secret."
+        required: false
+        default: ""
+        type: string
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
 
 jobs:
   publish:
@@ -84,15 +88,8 @@ jobs:
       - name: Pack
         run: dotnet pack ${{ inputs.solution }} --configuration "${{ inputs.buildConfiguration }}" --no-build -o artifacts /p:Version=${{ steps.version.outputs.package_version }}
 
-      - name: NuGet Login (OIDC)
-        uses: NuGet/login@v1
-        id: login
-        continue-on-error: true
-        with:
-          user: ${{ secrets.NUGET_USER }}
-
       - name: Publish to NuGet
         run: |
-          KEY="${{ steps.login.outputs.NUGET_API_KEY }}"
+          KEY="${{ inputs.nuget_api_key }}"
           if [ -z "$KEY" ]; then KEY="${{ secrets.NUGET_API_KEY }}"; fi
           dotnet nuget push artifacts/**/*.nupkg -k "$KEY" -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -38,7 +38,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
 
 jobs:
   publish:
@@ -88,11 +87,5 @@ jobs:
       - name: Pack
         run: dotnet pack ${{ inputs.solution }} --configuration "${{ inputs.buildConfiguration }}" --no-build -o artifacts /p:Version=${{ steps.version.outputs.package_version }}
 
-      - name: Nuget Login (OIDC -> Temp API Key)
-        uses: NuGet/login@v1
-        id: login
-        with:
-          user: ${{ secrets.NUGET_USER }}
-
       - name: Publish to NuGet
-        run: dotnet nuget push artifacts/**/*.nupkg -k ${{steps.login.outputs.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push artifacts/**/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -89,7 +89,4 @@ jobs:
         run: dotnet pack ${{ inputs.solution }} --configuration "${{ inputs.buildConfiguration }}" --no-build -o artifacts /p:Version=${{ steps.version.outputs.package_version }}
 
       - name: Publish to NuGet
-        run: |
-          KEY="${{ inputs.nuget_api_key }}"
-          if [ -z "$KEY" ]; then KEY="${{ secrets.NUGET_API_KEY }}"; fi
-          dotnet nuget push artifacts/**/*.nupkg -k "$KEY" -s https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push artifacts/**/*.nupkg -k "${{ inputs.nuget_api_key }}" -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -85,9 +85,9 @@ jobs:
         run: dotnet pack ${{ inputs.solution }} --configuration "${{ inputs.buildConfiguration }}" --no-build -o artifacts /p:Version=${{ steps.version.outputs.package_version }}
 
       - name: NuGet Login (OIDC)
-        if: secrets.NUGET_USER != ''
         uses: NuGet/login@v1
         id: login
+        continue-on-error: true
         with:
           user: ${{ secrets.NUGET_USER }}
 

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -31,9 +31,14 @@ on:
         required: false
         default: "release-drafter.yml"
         type: string
+      nuget_api_key:
+        description: "NuGet API key obtained via OIDC in the caller. Falls back to NUGET_API_KEY secret."
+        required: false
+        default: ""
+        type: string
     secrets:
       NUGET_API_KEY:
-        required: true
+        required: false
 
 permissions:
   contents: write
@@ -87,5 +92,12 @@ jobs:
       - name: Pack
         run: dotnet pack ${{ inputs.solution }} --configuration "${{ inputs.buildConfiguration }}" --no-build -o artifacts /p:Version=${{ steps.version.outputs.package_version }}
 
+      - name: Mask NuGet API key
+        if: inputs.nuget_api_key != ''
+        run: echo "::add-mask::${{ inputs.nuget_api_key }}"
+
       - name: Publish to NuGet
-        run: dotnet nuget push artifacts/**/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
+        run: |
+          KEY="${{ inputs.nuget_api_key }}"
+          if [ -z "$KEY" ]; then KEY="${{ secrets.NUGET_API_KEY }}"; fi
+          dotnet nuget push artifacts/**/*.nupkg -k "$KEY" -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -87,5 +87,11 @@ jobs:
       - name: Pack
         run: dotnet pack ${{ inputs.solution }} --configuration "${{ inputs.buildConfiguration }}" --no-build -o artifacts /p:Version=${{ steps.version.outputs.package_version }}
 
+      - name: Nuget Login (OIDC -> Temp API Key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Publish to NuGet
-        run: dotnet nuget push artifacts/**/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push artifacts/**/*.nupkg -k ${{steps.login.outputs.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -38,6 +38,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   publish:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,10 +21,6 @@ on:
         required: false
         default: "Release"
         type: string
-    secrets:
-      NUGET_API_KEY:
-        required: true
-
 permissions:
   contents: write
 
@@ -81,11 +77,8 @@ jobs:
       - name: Pack
         run: dotnet pack ${{ inputs.solution }} --configuration "${{ needs.resolve.outputs.configuration }}" --no-build -o artifacts /p:Version=${{ needs.resolve.outputs.version }} /p:InformationalVersion=${{ needs.resolve.outputs.version }}
 
-      - name: Nuget Login (OIDC -> Temp API Key)
-        uses: NuGet/login@v1
-        id: login
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
         with:
-          user: ${{ secrets.NUGET_USER }}
-
-      - name: Publish to NuGet
-        run: dotnet nuget push artifacts/**/*.nupkg -k ${{steps.login.outputs.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
+          name: nuget-packages
+          path: artifacts/**/*.nupkg

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -81,5 +81,11 @@ jobs:
       - name: Pack
         run: dotnet pack ${{ inputs.solution }} --configuration "${{ needs.resolve.outputs.configuration }}" --no-build -o artifacts /p:Version=${{ needs.resolve.outputs.version }} /p:InformationalVersion=${{ needs.resolve.outputs.version }}
 
+      - name: Nuget Login (OIDC -> Temp API Key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Publish to NuGet
-        run: dotnet nuget push artifacts/**/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push artifacts/**/*.nupkg -k ${{steps.login.outputs.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -48,6 +48,79 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 ```
 
+## NuGet Trusted Publishing (OIDC)
+
+NuGet packages are published using [NuGet Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/publish-a-package#trusted-publishers) via GitHub's OIDC token exchange rather than a static API key.
+
+### Why the push step lives in the caller
+
+GitHub's OIDC token includes a `job_workflow_ref` claim that identifies the workflow file where the job physically runs. NuGet.org's trusted publisher policy validates this claim against the configured workflow path.
+
+When a job runs inside a reusable workflow (`.github/workflows/publish-preview.yml`), the `job_workflow_ref` points to **devops-templates** — not the calling repository. NuGet.org rejects this because the trusted publisher policy is registered against the caller's workflow path (e.g. `LayeredCraft/my-repo/.github/workflows/publish-preview.yaml`).
+
+To satisfy the policy, the `NuGet/login` OIDC exchange must happen in a job that runs directly in the **caller's** workflow, not inside the shared template.
+
+### How it works
+
+The `publish-preview.yml` and `publish-release.yml` shared workflows handle everything up to and including packing, then upload the `.nupkg` files as a GitHub Actions artifact. The caller is responsible for a separate `push` job that uses the `nuget-push` composite action:
+
+```
+build job (shared workflow)     → resolve version, build, test, pack, upload-artifact
+push job  (caller, composite)   → NuGet OIDC login, download-artifact, dotnet nuget push
+```
+
+### `nuget-push` composite action
+
+Located at `.github/actions/nuget-push/action.yml`. Handles the full push flow in three steps:
+
+1. Exchange GitHub OIDC token for a temporary NuGet API key via `NuGet/login@v1`
+2. Download the `nuget-packages` artifact produced by the build job
+3. Push all `.nupkg` files to NuGet.org
+
+Because it is a **composite action** (not a reusable workflow), it runs inline inside the caller's job — so `job_workflow_ref` remains the caller's workflow path.
+
+### Caller setup
+
+Each repo's publish workflow needs a `push` job with `id-token: write` permission:
+
+```yaml
+permissions:
+  contents: write   # for release-drafter / release creation
+
+jobs:
+  build:
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@main
+    with:
+      solution: MyProject.sln
+      dotnetVersion: 9.0.x
+      hasTests: true
+    secrets: inherit
+
+  push:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: LayeredCraft/devops-templates/.github/actions/nuget-push@main
+        with:
+          nuget_user: ${{ secrets.NUGET_USER }}
+```
+
+### NuGet.org trusted publisher configuration
+
+For each package, add a trusted publisher entry on NuGet.org pointing to the **caller repo's** workflow file:
+
+| Field | Value |
+|---|---|
+| Repository owner | `LayeredCraft` (or your org) |
+| Repository name | the calling repo (e.g. `my-repo`) |
+| Workflow | `.github/workflows/publish-preview.yaml` |
+| Environment | *(leave blank)* |
+
+The `NUGET_USER` secret must be the username of the account that **created** the trusted publisher policy (not necessarily the package owner).
+
 ## Permissions
 When using these shared workflows, make sure to enable Read and Write permissions for your GitHub Actions. This is necessary for the workflows to access and modify the repository contents as needed.
 


### PR DESCRIPTION
## Summary
Updates the preview and release publish workflows to authenticate with NuGet using `NuGet/login@v1`. This replaces the long-lived `NUGET_API_KEY` secret usage with a temporary API key generated from the configured NuGet user.

## Changes
- Added a `Nuget Login (OIDC -> Temp API Key)` step to `.github/workflows/publish-preview.yml` and `.github/workflows/publish-release.yml`.
- Updated `dotnet nuget push` to use `steps.login.outputs.NUGET_API_KEY` for publishing packages.

## Validation
- Reviewed the workflow diff locally.
- Not run: GitHub Actions workflow execution requires the PR/check environment.