### PR TITLE
feat(nuget-push): support artifact name patterns for matrix builds

### DIFF
--- a/.github/actions/nuget-push/action.yml
+++ b/.github/actions/nuget-push/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: "NuGet.org username of the trusted publisher policy creator."
     required: true
   artifact_name:
-    description: "Name of the artifact containing the .nupkg files."
+    description: "Artifact name or glob pattern (e.g. 'nuget-packages-*') to download. Supports multiple artifacts via pattern."
     required: false
     default: "nuget-packages"
 
@@ -22,8 +22,9 @@ runs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: ${{ inputs.artifact_name }}
+        pattern: ${{ inputs.artifact_name }}
         path: artifacts
+        merge-multiple: true
 
     - name: Push to NuGet
       shell: bash

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -31,6 +31,11 @@ on:
         required: false
         default: "release-drafter.yml"
         type: string
+      artifact_name:
+        description: "Name for the uploaded artifact. Override when using a matrix to ensure uniqueness per entry."
+        required: false
+        default: "nuget-packages"
+        type: string
 permissions:
   contents: write
   pull-requests: write
@@ -86,5 +91,5 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: nuget-packages
+          name: ${{ inputs.artifact_name }}
           path: artifacts/**/*.nupkg


### PR DESCRIPTION
## Summary

- Add `artifact_name` input to `publish-preview.yml` (default: `nuget-packages`) so matrix callers can upload a distinct artifact per variant without naming collisions
- Update `nuget-push` composite action to use `pattern:` + `merge-multiple: true` on `actions/download-artifact@v4`, supporting both exact names (single build, default behavior unchanged) and glob patterns (matrix builds, e.g. `nuget-packages-ef*`)

## Why

When a reusable workflow is called via a matrix strategy, all parallel jobs share the same workflow run. Two jobs uploading to the same artifact name (`nuget-packages`) causes a conflict. Callers can now pass a unique `artifact_name` per matrix entry and collect all variants in the push job with a glob pattern.

## Test plan

- [ ] Verify `dynamodb-efcore-provider` matrix preview build uploads `nuget-packages-ef10` and `nuget-packages-ef11` successfully
- [ ] Verify push job downloads both artifacts via `nuget-packages-ef*` pattern and pushes to NuGet.org
- [ ] Verify existing single-build repos (default `artifact_name: nuget-packages`) still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)