### PR TITLE
ci(github): use app token for dependabot merges

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,16 +19,24 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Generate app token
+        id: app-token
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.DEPENDABOT_AUTOMERGE_APP_ID }}
+          private-key: ${{ secrets.DEPENDABOT_AUTOMERGE_PRIVATE_KEY }}
+
       - name: Approve PR
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps['app-token'].outputs.token }}
 
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps['app-token'].outputs.token }}


### PR DESCRIPTION
## Summary

Updates the Dependabot auto-merge workflow to use the repository GitHub App token for approval and auto-merge actions instead of `GITHUB_TOKEN`. This keeps downstream workflows from being suppressed after Dependabot auto-merges.

## Changes

- Adds a SHA-pinned `actions/create-github-app-token` step using `DEPENDABOT_AUTOMERGE_APP_ID` and `DEPENDABOT_AUTOMERGE_PRIVATE_KEY`.
- Keeps `dependabot/fetch-metadata` on `secrets.GITHUB_TOKEN`.
- Uses the generated app token for `gh pr review --approve` and `gh pr merge --auto --squash`.
- References the hyphenated `app-token` step ID with bracket notation.

## Validation

- Workflow-only change; reviewed YAML and GitHub Actions expression syntax.
